### PR TITLE
`CatchService` and related methods in RESTclient

### DIFF
--- a/src/main/java/com/cliapp/client/RESTClient.java
+++ b/src/main/java/com/cliapp/client/RESTClient.java
@@ -124,6 +124,11 @@ public class RESTClient {
             return null;
         }
     }
+
+
+
+    // === Public catch-related methods ===
+
     public List<Catch> getAvailableCatches() {
         return getList(CATCH_ENDPOINT, new TypeReference<List<Catch>>() {});
     }
@@ -132,12 +137,18 @@ public class RESTClient {
         return getList(CATCH_ENDPOINT + "/species/" + speciesName, new TypeReference<List<Catch>>() {});
     }
 
-    public List<Order> getOrdersForCustomer(String username) {
-        return getList(ORDER_ENDPOINT + "/customer/" + username, new TypeReference<List<Order>>() {});
-    }
-
     public List<Catch> getCatchesByFisher(String username) {
         return getList(CATCH_ENDPOINT + "/fisher/" + username, new TypeReference<List<Catch>>() {});
+    }
+
+    public List<Catch> getSpeciesAvailableAtLanding(String landingName) {
+        return getList(CATCH_ENDPOINT + "/species/" + landingName, new TypeReference<List<Catch>>() {});
+    }
+
+    // === other methods ===
+
+    public List<Order> getOrdersForCustomer(String username) {
+        return getList(ORDER_ENDPOINT + "/customer/" + username, new TypeReference<List<Order>>() {});
     }
 
     public Person getCustomerByUsername(String username) {
@@ -147,4 +158,6 @@ public class RESTClient {
     public FisherProfile getFisherByUsername(String username) {
         return getObject("/api/person/fisher/" + username, FisherProfile.class);
     }
+
+
 }

--- a/src/main/java/com/cliapp/service/CatchService.java
+++ b/src/main/java/com/cliapp/service/CatchService.java
@@ -2,48 +2,31 @@ package com.cliapp.service;
 
 import com.cliapp.client.RESTClient;
 import com.cliapp.model.Catch;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 
-// Check if this matches requirements for assignment
 public class CatchService {
     private final RESTClient client;
-    private final ObjectMapper mapper;
 
-    public CatchService(String apiBaseUrl) {
-        this.client = new RESTClient();
-        this.client.setServerURL(apiBaseUrl);
-        this.mapper = new ObjectMapper();
+    public CatchService(RESTClient client) {
+        this.client = client;
     }
 
-    public List<Catch> getAllAvailableCatches() {
-        try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(client.getServerURL() + "/api/catch/available"))
-                    .GET()
-                    .build();
-
-            HttpResponse<String> response = client.getClient().send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() == 200) {
-                return mapper.readValue(response.body(), new TypeReference<>() {});
-            } else {
-                System.out.println("Error: " + response.statusCode());
-            }
-        } catch (Exception e) {
-            System.out.println("Failed to fetch available catches: " + e.getMessage());
-        }
-
-        return Collections.emptyList();
+    public List<Catch> getAvailableCatches() {
+        return client.getAvailableCatches();
     }
 
-    //@GetMapping("/available/species-by-landing")
+    public List<Catch> getCatchesBySpecies(String speciesName) {
+        return client.getCatchesBySpecies(speciesName);
+    }
 
+    public List<Catch> getCatchesByFisher(String username) {
+        return client.getCatchesByFisher(username);
+    }
+
+    public List<Catch> getSpeciesAvailableAtLanding(String landingName) {
+        return client.getSpeciesAvailableAtLanding(landingName);
+    }
 }
+
 


### PR DESCRIPTION
Refactor `CatchService` to delegate catch-related operations to `REST…Client`. Simplify HTTP request handling and add new API methods for species availability and fisher-specific catches.