### PR TITLE
Refactor `CatchService` and `RESTClient` for improved method naming a…

### DIFF
--- a/src/main/java/com/cliapp/client/RESTClient.java
+++ b/src/main/java/com/cliapp/client/RESTClient.java
@@ -38,12 +38,6 @@ public class RESTClient {
     private String serverURL;
     private HttpClient client;
 
-    private final ObjectMapper mapper;
-
-    public RESTClient() {
-        this.mapper = createDefaultMapper();
-    }
-
 
     public String getServerURL() {
         return serverURL;
@@ -56,6 +50,13 @@ public class RESTClient {
             client  = HttpClient.newHttpClient();
         }
         return client;
+    }
+
+
+    private final ObjectMapper mapper;
+
+    public RESTClient() {
+        this.mapper = createDefaultMapper();
     }
 
     private ObjectMapper createDefaultMapper() {
@@ -146,11 +147,25 @@ public class RESTClient {
         return getList(CATCH_ENDPOINT, new TypeReference<>() {});
     }
 
+    public List<CatchViewDTO> getCatchesBySpecies(String speciesName) {
+        return getList(CATCH_ENDPOINT + "/speciesName", new TypeReference<>() {});
+    }
+
     // === catches by fisher ===
     private List<CatchViewDTO> getCatchesByFisherSubpath(long id, String subPath) {
         String url = String.format(FISHER_CATCHES, id) + subPath;
         return getList(url, new TypeReference<>() {});
     } // return getCatchesByFisherSubpath(id, "/expired");
+
+
+    public List<CatchViewDTO> getFisherCatchesBySpecies(long id, String species) {
+        return getCatchesByFisherSubpath(id, "/expired");
+    } // return getCatchesByFisherSubpath(id, "/expired");
+
+    public List<CatchViewDTO> getFisherCatchesById(long id) {
+        return getCatchesByFisherSubpath(id, "");
+    }
+
 
 
     // === catches by search ===

--- a/src/main/java/com/cliapp/controller/FisherController.java
+++ b/src/main/java/com/cliapp/controller/FisherController.java
@@ -50,7 +50,7 @@ public class FisherController {
     }
 
     private void viewMyCatches(long id) {
-        List<CatchViewDTO> catchViewDTOS = catchService.getCatchesByFisherId(id);
+        List<CatchViewDTO> catchViewDTOS = catchService.getFisherCatchesById(id);
         ConsoleUI.header("Your Catches");
         if (catchViewDTOS.isEmpty()) {
             ConsoleUI.info("No catches found.");

--- a/src/main/java/com/cliapp/service/CatchService.java
+++ b/src/main/java/com/cliapp/service/CatchService.java
@@ -29,8 +29,8 @@ public class CatchService {
 //        return client.getCatchesByFisherName(username);
 //    }
 
-    public List<CatchViewDTO> getCatchesByFisherId(long id) {
-        return client.getCatchesByFisherId(id);
+    public List<CatchViewDTO> getFisherCatchesById(long id) {
+        return client.getFisherCatchesById(id);
     }
 
     public List<CatchViewDTO> getSpeciesAvailableAtLanding(String landingName) {


### PR DESCRIPTION
…nd new functionality

- Rename `getCatchesByFisherId` to `getFisherCatchesById` for clarity.
- Add `getCatchesBySpecies` and `getFisherCatchesBySpecies` to `RESTClient` for enhanced filtering capabilities.
- Fix mapper initialization location in `RESTClient` constructor.