### PR TITLE
Add comprehensive unit tests for `CatchService` methods and update `C…

### DIFF
--- a/src/main/java/com/cliapp/model/CatchViewDTO.java
+++ b/src/main/java/com/cliapp/model/CatchViewDTO.java
@@ -7,31 +7,32 @@ import java.time.LocalDateTime;
 
 public class CatchViewDTO {
     private long id;
-
     private String speciesName;
-
     private BigDecimal quantityInKg;
 
     @JsonProperty("price")
     private BigDecimal pricePerKg;
-
     private boolean available;
-
     private String fisherName;
-
     private LocalDateTime timeStamp;
-
     private Long landingId;
-
     private double latitude;
     private double longitude;
-    
     private String landingName;
-
     @JsonProperty("pickup_instructions")
     private String pickupInstructions;
-
     private LocalDateTime pickupTime;
+
+    public CatchViewDTO(long id, String speciesName, BigDecimal quantityInKg, BigDecimal pricePerKg, boolean available, String fisherName, String landingName) {
+        this.id = id;
+        this.speciesName = speciesName;
+        this.quantityInKg = quantityInKg;
+        this.pricePerKg = pricePerKg;
+        this.available = available;
+        this.fisherName = fisherName;
+        this.landingName = landingName;
+    }
+
 
     public long getId() {
         return id;

--- a/src/test/java/com/cliapp/service/CatchServiceTest.java
+++ b/src/test/java/com/cliapp/service/CatchServiceTest.java
@@ -1,59 +1,89 @@
 package com.cliapp.service;
-
 import com.cliapp.client.RESTClient;
 import com.cliapp.model.CatchViewDTO;
+
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
-import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-class CatchServiceTest {
+public class CatchServiceTest {
+
+    private RESTClient client;
+    private CatchService service;
+
+    private final CatchViewDTO sampleCatch = new CatchViewDTO(
+            1, "Halibut",
+            BigDecimal.valueOf(10), BigDecimal.valueOf(25), true, "fisher1",
+             "st. John's");
+
+    @BeforeEach
+    public void setup() {
+        client = mock(RESTClient.class);
+        service = new CatchService(client);
+    }
 
     @Test
-    void getAvailableCatches_returnsListFromClient() {
-        // Arrange
-        RESTClient mockClient = mock(RESTClient.class);
-        CatchService catchService = new CatchService(mockClient);
+    public void testGetAll_success() {
+        when(client.getList(eq("/catch"), any())).thenReturn(List.of(sampleCatch));
 
-        CatchViewDTO mockCatchViewDTO = new CatchViewDTO("cod", 2, 5, "here", true);  // populate fields if needed
-        when(mockClient.getAvailableCatches()).thenReturn(List.of(mockCatchViewDTO));
-
-        // Act
-        List<CatchViewDTO> result = catchService.getAvailableCatches();
-
-        // Assert
+        List<CatchViewDTO> result = service.getAll();
         assertEquals(1, result.size());
-        assertSame(mockCatchViewDTO, result.getFirst());
-        verify(mockClient).getAvailableCatches();
+        assertEquals("Halibut", result.get(0).getSpeciesName());
     }
 
     @Test
-    void getAvailableCatches_returnsEmptyList_whenClientThrowsException() {
-        // Arrange
-        RESTClient mockClient = mock(RESTClient.class);
-        CatchService catchService = new CatchService(mockClient);
+    public void testGetAll_failure() {
+        when(client.getList(eq("/catch"), any())).thenThrow(new RuntimeException("fail"));
 
-        when(mockClient.getAvailableCatches()).thenThrow(new RuntimeException("Server error"));
-
-        // Act
-        List<CatchViewDTO> result = catchService.getAvailableCatches();
-
-        // Assert
-        assertTrue(result.isEmpty(), "Expected empty list when client throws");
-        verify(mockClient).getAvailableCatches();
+        List<CatchViewDTO> result = service.getAll();
+        assertTrue(result.isEmpty());
     }
 
     @Test
-    void getCatchesBySpecies() {
+    public void testGetAvailableCatches_success() {
+        when(client.getAvailableCatches()).thenReturn(List.of(sampleCatch));
+
+        List<CatchViewDTO> result = service.getAvailableCatches();
+        assertEquals(1, result.size());
     }
 
     @Test
-    void getCatchesByFisher() {
+    public void testSearchBySpeciesName_success() {
+        when(client.searchCatches(eq("Halibut"), isNull())).thenReturn(List.of(sampleCatch));
+
+        List<CatchViewDTO> result = service.searchBySpeciesName("Halibut");
+        assertEquals(1, result.size());
     }
 
     @Test
-    void getSpeciesAvailableAtLanding() {
+    public void testSearchByLandingName_failure() {
+        when(client.searchCatches(isNull(), eq("St. John’s"))).thenThrow(new RuntimeException("No connection"));
+
+        List<CatchViewDTO> result = service.searchByLandingName("St. John’s");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testGetCatchesByFisherId_success() {
+        when(client.getCatchesByFisherId(42L)).thenReturn(List.of(sampleCatch));
+
+        List<CatchViewDTO> result = service.getCatchesByFisherId(42L);
+        assertEquals("Halibut", result.get(0).getSpeciesName());
+    }
+
+    @Test
+    public void testGetCatchCountBySpecies() {
+        when(client.searchCatches(eq("Halibut"), isNull())).thenReturn(List.of(sampleCatch, sampleCatch));
+
+        Map<String, Long> count = service.getCatchCountBySpecies("Halibut");
+        assertEquals(1, count.size());
+        assertEquals(2, count.get("Halibut"));
     }
 }


### PR DESCRIPTION
…atchViewDTO` constructor

- Add missing unit tests covering various scenarios in `CatchService`, including edge cases and error handling.
- Introduce overloaded constructor in `CatchViewDTO` for convenient object instantiation.
- Cleanup: remove redundant imports, add formatting fixes in test classes.